### PR TITLE
Todo List app functionality tests: Experiment with dynamically generating more systematic tests for status synchronization based on the app info collected in the prior discovery phase, tests that don't leave as much up to the LLM driver

### DIFF
--- a/src/benchmark-functionality-tests/test-lib/report.ts
+++ b/src/benchmark-functionality-tests/test-lib/report.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { Logger } from "../../utils/logger/logger.js";
-
+import { jsonStringify } from "../../utils/logger/pretty.js";
 /*********************************
     For report
 ************************************/
@@ -60,6 +60,9 @@ export class Reporter {
   constructor(private logger: Logger) {}
 
   report(results: TestSuiteResults): void {
+    this.logger.info(jsonStringify(results));
+
+    // Summary logging
     if (results.summary.failed > 0) {
       this.logger.error(
         `✗ Suite "${results.name}" failed: ${results.summary.failed}/${results.summary.total} tests failed`,
@@ -86,8 +89,6 @@ export class Reporter {
     } else {
       this.logger.info(`✓ All tests in suite ${results.name} passed`);
     }
-    this.logger.info(JSON.stringify(results, null, 2));
-
     this.logger.info(
       `Test execution for ${results.name} completed in ${(results.summary.duration / 1000).toFixed(1)}s`,
     );

--- a/src/benchmark-functionality-tests/test-lib/runner.ts
+++ b/src/benchmark-functionality-tests/test-lib/runner.ts
@@ -63,11 +63,13 @@ export class TestRunner {
     // Run tests
     const results = await Promise.all(
       suite.getTests().map(async (test) => {
-        return await test.run(
+        const result = await test.run(
           new NonVisionTestCaseAgent(this.config, this.getLogger()),
           context,
           this.config,
         );
+        result.name = test.descriptiveName;
+        return result;
       }),
     );
 

--- a/src/benchmark-functionality-tests/test-lib/suite.ts
+++ b/src/benchmark-functionality-tests/test-lib/suite.ts
@@ -67,10 +67,10 @@ export class Suite {
 // }
 
 export interface TestCase {
-  description: string;
+  descriptiveName: string;
   run(
     agent: NonVisionTestCaseAgent,
-    fixtures: TestContext,
+    context: TestContext,
     config: TestRunnerConfig,
   ): Promise<TestResult>;
 }

--- a/src/benchmark-functionality-tests/test-lib/suite.ts
+++ b/src/benchmark-functionality-tests/test-lib/suite.ts
@@ -37,15 +37,6 @@ export class Suite {
   getTests() {
     return this.tests;
   }
-
-  // withFixtures(makers: FixtureMaker[]) {
-  //   this.fixtureMakers = makers;
-  //   return this;
-  // }
-
-  // getFixtureMakers() {
-  //   return this.fixtureMakers;
-  // }
 }
 
 /**************************

--- a/src/benchmark-functionality-tests/tests/evolvability/todolist-easy/attribute-isolation-tests/test-factory.ts
+++ b/src/benchmark-functionality-tests/tests/evolvability/todolist-easy/attribute-isolation-tests/test-factory.ts
@@ -17,7 +17,7 @@ import dedent from "dedent";
 
 export function makeAttributeIsolationTest(attribute: TaskAttribute): TestCase {
   return {
-    description: `Test that changing a task's ${attribute.getPrettyName()} doesn't affect other tasks`,
+    descriptiveName: `Test that changing a task's ${attribute.getPrettyName()} doesn't affect other tasks`,
     async run(
       agent: NonVisionTestCaseAgent,
       context: TestContext,

--- a/src/benchmark-functionality-tests/tests/evolvability/todolist-easy/basic-tests/test-cases.ts
+++ b/src/benchmark-functionality-tests/tests/evolvability/todolist-easy/basic-tests/test-cases.ts
@@ -10,7 +10,7 @@ import { appInfoId } from "../test-strategy.js";
 import dedent from "dedent";
 
 export const checkMoreThanDoneNotDoneStatuses: TestCase = {
-  description: "Test that the app has more than done/not-done statuses",
+  descriptiveName: "Test that the app has more than done/not-done statuses",
   async run(
     agent: NonVisionTestCaseAgent,
     context: TestContext,

--- a/src/benchmark-functionality-tests/tests/evolvability/todolist-easy/shared/task-attribute.ts
+++ b/src/benchmark-functionality-tests/tests/evolvability/todolist-easy/shared/task-attribute.ts
@@ -9,6 +9,7 @@ type AttributeViews = AppInfo["taskInfo"]["views"][AttributeId];
 export interface TaskAttribute {
   attributeId: AttributeId;
   getPrettyName(): string;
+  getAttributeValuesForTesting(appInfo: AppInfo): string[];
   getAttributeViews(appInfo: AppInfo): AttributeViews;
   getInfoForStateSynchTests(appInfo: AppInfo): string;
 }
@@ -16,6 +17,7 @@ export interface TaskAttribute {
 export const PriorityTaskAttribute: TaskAttribute = {
   attributeId: "priority",
   getPrettyName: () => "priority",
+  getAttributeValuesForTesting: (app) => app.taskInfo.priorityLevels,
   getAttributeViews: (app) => app.taskInfo.views.priority,
   getInfoForStateSynchTests: (app) =>
     JSON.stringify(app.taskInfo.views.priority),
@@ -24,6 +26,9 @@ export const PriorityTaskAttribute: TaskAttribute = {
 export const DueDateTaskAttribute: TaskAttribute = {
   attributeId: "dueDate",
   getPrettyName: () => "due date",
+  getAttributeValuesForTesting: (app) => {
+    return ["tomorrow", "next week", "yesterday (or past date)"];
+  },
   getAttributeViews: (app) => app.taskInfo.views.dueDate,
   getInfoForStateSynchTests: (app) =>
     JSON.stringify(app.taskInfo.views.dueDate),
@@ -32,6 +37,7 @@ export const DueDateTaskAttribute: TaskAttribute = {
 export const StatusTaskAttribute: TaskAttribute = {
   attributeId: "status",
   getPrettyName: () => "status",
+  getAttributeValuesForTesting: (app) => app.taskInfo.statuses,
   getAttributeViews: (app) => app.taskInfo.views.status,
   getInfoForStateSynchTests: (app) =>
     JSON.stringify({

--- a/src/benchmark-functionality-tests/tests/evolvability/todolist-easy/shared/task-attribute.ts
+++ b/src/benchmark-functionality-tests/tests/evolvability/todolist-easy/shared/task-attribute.ts
@@ -9,7 +9,7 @@ type AttributeViews = AppInfo["taskInfo"]["views"][AttributeId];
 export interface TaskAttribute {
   attributeId: AttributeId;
   getPrettyName(): string;
-  getAttributeValuesForTesting(appInfo: AppInfo): string[];
+  getAttributeValues(appInfo: AppInfo): string[];
   getAttributeViews(appInfo: AppInfo): AttributeViews;
   getInfoForStateSynchTests(appInfo: AppInfo): string;
 }
@@ -17,7 +17,7 @@ export interface TaskAttribute {
 export const PriorityTaskAttribute: TaskAttribute = {
   attributeId: "priority",
   getPrettyName: () => "priority",
-  getAttributeValuesForTesting: (app) => app.taskInfo.priorityLevels,
+  getAttributeValues: (app) => app.taskInfo.priorityLevels,
   getAttributeViews: (app) => app.taskInfo.views.priority,
   getInfoForStateSynchTests: (app) =>
     JSON.stringify(app.taskInfo.views.priority),
@@ -26,7 +26,7 @@ export const PriorityTaskAttribute: TaskAttribute = {
 export const DueDateTaskAttribute: TaskAttribute = {
   attributeId: "dueDate",
   getPrettyName: () => "due date",
-  getAttributeValuesForTesting: (app) => {
+  getAttributeValues: (app) => {
     return ["tomorrow", "next week", "yesterday (or past date)"];
   },
   getAttributeViews: (app) => app.taskInfo.views.dueDate,
@@ -37,7 +37,7 @@ export const DueDateTaskAttribute: TaskAttribute = {
 export const StatusTaskAttribute: TaskAttribute = {
   attributeId: "status",
   getPrettyName: () => "status",
-  getAttributeValuesForTesting: (app) => app.taskInfo.statuses,
+  getAttributeValues: (app) => app.taskInfo.statuses,
   getAttributeViews: (app) => app.taskInfo.views.status,
   getInfoForStateSynchTests: (app) =>
     JSON.stringify({

--- a/src/benchmark-functionality-tests/tests/evolvability/todolist-easy/state-synchronization-tests/test-factory.ts
+++ b/src/benchmark-functionality-tests/tests/evolvability/todolist-easy/state-synchronization-tests/test-factory.ts
@@ -1,5 +1,8 @@
 import type * as z from "zod";
-import type { TaskAttribute } from "../shared/task-attribute.js";
+import {
+  type TaskAttribute,
+  StatusTaskAttribute,
+} from "../shared/task-attribute.js";
 import type { TestContext } from "../../../../test-lib/context.js";
 import type { TestResult } from "../../../../test-lib/report.js";
 import type { TestCase } from "../../../../test-lib/suite.js";
@@ -17,7 +20,7 @@ import dedent from "dedent";
 /** Make a 'I'm feeling lucky' state synchronization test case */
 export function makeChanceyStateSynchTest(attribute: TaskAttribute): TestCase {
   return {
-    description: `Test state synchronization of ${attribute.getPrettyName()} state (if applicable)`,
+    descriptiveName: `Test state synchronization of ${attribute.getPrettyName()} state (if applicable)`,
     async run(
       agent: NonVisionTestCaseAgent,
       context: TestContext,
@@ -49,32 +52,56 @@ export function makeChanceyStateSynchTest(attribute: TaskAttribute): TestCase {
   };
 }
 
-// /**********************************************************
-//     App Info Driven State Synchronization Test Factory
-// ***********************************************************/
-// // TODO: Not sure what a good name for this is.
+/**********************************************************
+      Per Mutator State Synchronization Test Factory
+***********************************************************/
+// TODO: Not sure what a good name for this is.
 
-// export function makeAppInfoDrivenStateSynchTests(
-//   attribute: TaskAttribute,
-// ): Array<NonVisionTestCase> {
-//   return [{
-//     type: "non-vision" as const,
-//     description: `More deterministic, more app-info-dependent, test of state synchronization of ${attribute.getPrettyName()} state (if applicable)`,
-//     async run(
-//       agent: NonVisionTestCaseAgent,
-//       fixtures: FixturesEnv,
-//       config: TestRunnerConfig,
-//     ): Promise<TestResult> {
-//       const appInfo = fixtures.get(appInfoId) as z.infer<
-//         typeof TodoListAppInfo
-//       >;
-//       const mutators = attribute
-//         .getAttributeViews(appInfo)
-//         .views.filter((view) => view.viewType === "mutator");
+/** Don't need to check the code for these more constrained tests */
+const makeJustPlaywrightToolsPrompt = (config: TestRunnerConfig) => dedent`
+  You can use Playwright MCP; the dev server has been started at port ${config.port}.`;
 
-//       return agent.check(dedent`
-//         ${makeBackgroundPrompt(config)}
-//         Test state synchronization of ${attribute.getPrettyName()} state (if applicable)`);
-//     },
-//   }];
-// }
+// TODO: Starting with just status to demonstrate the approach; can generalize to priority levels and due dates in the future
+/** Make more thorough tests for status synchronization based on the app info.
+ * For each mutator, test that changing the status via that mutator
+ * updates the other views accordingly.
+ *
+ * The key insight is that the app info identified by the discovery phase tends to be reliable,
+ * and the info there is enough for us to test this sort of test synchronization without leaving too much to the coding agent.
+ */
+export function makePerMutatorStateSyncTestsForStatus(
+  appInfo: z.infer<typeof TodoListAppInfo>,
+  fromStatus: string,
+  toStatus: string,
+): Array<TestCase> {
+  const attribute = StatusTaskAttribute;
+  const mutators = attribute
+    .getAttributeViews(appInfo)
+    .views.filter((view) => view.viewType === "mutator");
+  return mutators.map((mutator) => {
+    return {
+      descriptiveName: `Per-mutator state synchronization test - ${attribute.getPrettyName()}`,
+      async run(
+        agent: NonVisionTestCaseAgent,
+        _context: TestContext,
+        config: TestRunnerConfig,
+      ): Promise<TestResult> {
+        return await agent.check(dedent`
+            You are testing synchronization of ${attribute.getPrettyName()} in a Todo list app.
+            ${makeJustPlaywrightToolsPrompt(config)}
+            
+            Here is some information that someone else has gathered:
+            * The available statuses are ${JSON.stringify(attribute.getAttributeValuesForTesting(appInfo))}.
+            * The views or UI elements are:
+              ${attribute.getInfoForStateSynchTests(appInfo)}
+
+            Test state synchronization by
+            1. Creating a task with the status ${fromStatus}
+            2. Then change the status to ${toStatus} by using ${mutator}
+            3. Finally, check if the other views update accordingly.
+            The test passes if and only if all the other views update accordingly.
+          `);
+      },
+    };
+  });
+}

--- a/src/benchmark-functionality-tests/tests/evolvability/todolist-easy/state-synchronization-tests/test-factory.ts
+++ b/src/benchmark-functionality-tests/tests/evolvability/todolist-easy/state-synchronization-tests/test-factory.ts
@@ -81,8 +81,14 @@ export function makePerMutatorStateSyncTestsForStatus(
     .getAttributeViews(appInfo)
     .views.filter((view) => view.viewType === "mutator");
   return mutators.map((mutator) => {
+    // TODO: Could make this more robust
+    const mutatorName = mutator.shortDescription
+      .trim()
+      .split(" ")
+      .slice(0, 2)
+      .join(" ");
     return {
-      descriptiveName: `Per-mutator state synchronization test - ${attribute.getPrettyName()}`,
+      descriptiveName: `Per-mutator state synch - ${attribute.getPrettyName()} - ${mutatorName}`,
       async run(
         agent: NonVisionTestCaseAgent,
         _context: TestContext,

--- a/src/benchmark-functionality-tests/tests/evolvability/todolist-easy/state-synchronization-tests/test-factory.ts
+++ b/src/benchmark-functionality-tests/tests/evolvability/todolist-easy/state-synchronization-tests/test-factory.ts
@@ -66,8 +66,10 @@ const makeJustPlaywrightToolsPrompt = (config: TestRunnerConfig) => dedent`
  * For each mutator, test that changing the status via that mutator
  * updates the other views accordingly.
  *
- * The key insight is that the app info identified by the discovery phase tends to be reliable,
- * and the info there is enough for us to test this sort of test synchronization without leaving too much to the coding agent.
+ * The key insight, I think, is that
+ * (i) the discovery phase allows us to collect key info about the app under test
+ * (ii) we don't actually need that much info to test this sort of test synchronization systematically, without leaving too much to the coding agent,
+ * which in effect makes the discovery task simpler / more reliable. E.g., we don't need the discovery agent to actually identify bugs -- just need it to identify key UI elements and which are mutators.
  */
 export function makePerMutatorStateSyncTestsForStatus(
   appInfo: z.infer<typeof TodoListAppInfo>,

--- a/src/benchmark-functionality-tests/tests/evolvability/todolist-easy/state-synchronization-tests/test-factory.ts
+++ b/src/benchmark-functionality-tests/tests/evolvability/todolist-easy/state-synchronization-tests/test-factory.ts
@@ -57,6 +57,11 @@ export function makeChanceyStateSynchTest(attribute: TaskAttribute): TestCase {
 ***********************************************************/
 // TODO: Not sure what a good name for this is.
 
+export type StateTransition = {
+  from: string;
+  to: string;
+};
+
 /** Don't need to check the code for these more constrained tests */
 const makeJustPlaywrightToolsPrompt = (config: TestRunnerConfig) => dedent`
   You can use Playwright MCP; the dev server has been started at port ${config.port}.`;
@@ -75,8 +80,7 @@ const makeJustPlaywrightToolsPrompt = (config: TestRunnerConfig) => dedent`
  */
 export function makePerMutatorStateSyncTestsForStatus(
   appInfo: z.infer<typeof TodoListAppInfo>,
-  fromStatus: string,
-  toStatus: string,
+  stateTransition: StateTransition,
 ): Array<TestCase> {
   const attribute = StatusTaskAttribute;
   const mutators = attribute
@@ -101,13 +105,13 @@ export function makePerMutatorStateSyncTestsForStatus(
             ${makeJustPlaywrightToolsPrompt(config)}
             
             Here is some information that someone else has gathered:
-            * The available statuses are ${JSON.stringify(attribute.getAttributeValuesForTesting(appInfo))}.
+            * The available statuses are ${JSON.stringify(attribute.getAttributeValues(appInfo))}.
             * The views or UI elements are:
               ${attribute.getInfoForStateSynchTests(appInfo)}
 
             Test state synchronization by
-            1. Creating a task with the status ${fromStatus}
-            2. Then change the status to ${toStatus} by using ${mutator}
+            1. Creating a task with the status ${stateTransition.from}
+            2. Then change the status to ${stateTransition.to} by using ${mutator}
             3. Finally, check if the other views update accordingly.
             The test passes if and only if all the other views update accordingly.
           `);

--- a/src/benchmark-functionality-tests/tests/evolvability/todolist-easy/state-synchronization-tests/test-factory.ts
+++ b/src/benchmark-functionality-tests/tests/evolvability/todolist-easy/state-synchronization-tests/test-factory.ts
@@ -14,45 +14,6 @@ import { appInfoId } from "../test-strategy.js";
 import dedent from "dedent";
 
 /**********************************************************
-  'I'm feeling lucky' State Synchronization Test Factory
-***********************************************************/
-
-/** Make a 'I'm feeling lucky' state synchronization test case */
-export function makeChanceyStateSynchTest(attribute: TaskAttribute): TestCase {
-  return {
-    descriptiveName: `Test state synchronization of ${attribute.getPrettyName()} state (if applicable)`,
-    async run(
-      agent: NonVisionTestCaseAgent,
-      context: TestContext,
-      config: TestRunnerConfig,
-    ): Promise<TestResult> {
-      const appInfo = context.get(appInfoId) as z.infer<typeof TodoListAppInfo>;
-      config.logger.debugWith(appInfo, "AppInfo fixture");
-
-      return await agent.check(dedent`
-        ${makeBackgroundPrompt(config)}
-        Here is some information that someone else gathered about the views of or UI elements for the ${attribute.getPrettyName()} (and related things):
-        ${attribute.getInfoForStateSynchTests(appInfo)}
-
-        Your overall goal is to test synchronization of ${attribute.getPrettyName()}, broadly construed, as well as any synchronizations of this state with other key pieces of state.
-        In particular:
-        1. Skim the relevant code for more context -- it'll help with knowing what to focus on testing.
-        2. Think about the specification and what UI paths you have to explore to *thoroughly* test such synchronization before doing it.
-        E.g., if the ${attribute.getPrettyName()} is exposed in two ways, check if (i) changing it via one way also updates the other view and (ii) changing it via the other view also updates the first view.
-
-        Then evaluate as follows:
-        * If the ${attribute.getPrettyName()} is only exposed in one way and there are no interactions with other pieces of state, mark the test as passing.
-        * If the ${attribute.getPrettyName()} is exposed in more than one way in the UI, check if this state has been synchronized correctly across the different views.
-
-        Examples of synchronization failures:
-        - For an app with both an icon/badge and a text label for the status: Status icon updates but text label doesn't change
-        - For an app with both a detailed view and a summary view: Status changes in the detailed view but not in the summary view
-        `);
-    },
-  };
-}
-
-/**********************************************************
       Per Mutator State Synchronization Test Factory
 ***********************************************************/
 // TODO: Not sure what a good name for this is.
@@ -118,4 +79,44 @@ export function makePerMutatorStateSyncTestsForStatus(
       },
     };
   });
+}
+
+/*******************************************************************
+  (Obsolete but keeping around for comparison in the short term) 
+  'I'm feeling lucky' State Synchronization Test Factory
+********************************************************************/
+
+/** Make a 'I'm feeling lucky' state synchronization test case */
+export function makeChanceyStateSynchTest(attribute: TaskAttribute): TestCase {
+  return {
+    descriptiveName: `Test state synchronization of ${attribute.getPrettyName()} state (if applicable)`,
+    async run(
+      agent: NonVisionTestCaseAgent,
+      context: TestContext,
+      config: TestRunnerConfig,
+    ): Promise<TestResult> {
+      const appInfo = context.get(appInfoId) as z.infer<typeof TodoListAppInfo>;
+      config.logger.debugWith(appInfo, "AppInfo fixture");
+
+      return await agent.check(dedent`
+        ${makeBackgroundPrompt(config)}
+        Here is some information that someone else gathered about the views of or UI elements for the ${attribute.getPrettyName()} (and related things):
+        ${attribute.getInfoForStateSynchTests(appInfo)}
+
+        Your overall goal is to test synchronization of ${attribute.getPrettyName()}, broadly construed, as well as any synchronizations of this state with other key pieces of state.
+        In particular:
+        1. Skim the relevant code for more context -- it'll help with knowing what to focus on testing.
+        2. Think about the specification and what UI paths you have to explore to *thoroughly* test such synchronization before doing it.
+        E.g., if the ${attribute.getPrettyName()} is exposed in two ways, check if (i) changing it via one way also updates the other view and (ii) changing it via the other view also updates the first view.
+
+        Then evaluate as follows:
+        * If the ${attribute.getPrettyName()} is only exposed in one way and there are no interactions with other pieces of state, mark the test as passing.
+        * If the ${attribute.getPrettyName()} is exposed in more than one way in the UI, check if this state has been synchronized correctly across the different views.
+
+        Examples of synchronization failures:
+        - For an app with both an icon/badge and a text label for the status: Status icon updates but text label doesn't change
+        - For an app with both a detailed view and a summary view: Status changes in the detailed view but not in the summary view
+        `);
+    },
+  };
 }

--- a/src/benchmark-functionality-tests/tests/evolvability/todolist-easy/state-synchronization-tests/test-factory.ts
+++ b/src/benchmark-functionality-tests/tests/evolvability/todolist-easy/state-synchronization-tests/test-factory.ts
@@ -62,8 +62,10 @@ const makeJustPlaywrightToolsPrompt = (config: TestRunnerConfig) => dedent`
   You can use Playwright MCP; the dev server has been started at port ${config.port}.`;
 
 // TODO: Starting with just status to demonstrate the approach; can generalize to priority levels and due dates in the future
-/** Make more thorough tests for status synchronization based on the app info.
- * For each mutator, test that changing the status via that mutator
+/** Make tests for status synchronization based on the app info that
+ * (i) are more systematic and
+ * (ii) more constrained (e.g., we don't explicitly prompt the agent to check the code).
+ * In particular, for each mutator, test that changing the status via that mutator
  * updates the other views accordingly.
  *
  * The key insight, I think, is that

--- a/src/benchmark-functionality-tests/tests/evolvability/todolist-easy/test-strategy.ts
+++ b/src/benchmark-functionality-tests/tests/evolvability/todolist-easy/test-strategy.ts
@@ -38,8 +38,14 @@ export const strategy: SuiteGenerationStrategy = {
     // For each mutator that was identified in the previous discovery phase, we test that changing the status via that mutator updates the other views accordingly.
     // TODO: Starting with just status to demonstrate the approach; can generalize to priority levels and due dates in the future
     const dynamicTests = [
-      ...makePerMutatorStateSyncTestsForStatus(appInfo, "not-done", "done"),
-      ...makePerMutatorStateSyncTestsForStatus(appInfo, "done", "not-done"),
+      ...makePerMutatorStateSyncTestsForStatus(appInfo, {
+        from: "not-done",
+        to: "done",
+      }),
+      ...makePerMutatorStateSyncTestsForStatus(appInfo, {
+        from: "done",
+        to: "not-done",
+      }),
     ];
 
     const staticTests = [

--- a/src/benchmark-functionality-tests/tests/evolvability/todolist-easy/test-strategy.ts
+++ b/src/benchmark-functionality-tests/tests/evolvability/todolist-easy/test-strategy.ts
@@ -53,11 +53,12 @@ export const strategy: SuiteGenerationStrategy = {
       checkMoreThanDoneNotDoneStatuses,
 
       // 'I'm feeling lucky' State synchronization tests
-      // These don't seem to have as high a detection rate as the per-mutator tests,
-      // but I'm keeping them around for now because these are potentially complementary (e.g. when the discovery phase doesn't work well)
-      chanceyStateSynchStatus,
-      chanceyStateSynchPriority,
-      chanceyStateSynchDueDate,
+      // Commented these out because these don't have as a high a detection rate as the per-mutator tests;
+      // they also are not constrained enough (so there are occasional false positives).
+      // But haven't removed them totally because it's helpful in the short term to be able to cross check the per-mutator tests with these.
+      // chanceyStateSynchStatus,
+      // chanceyStateSynchPriority,
+      // chanceyStateSynchDueDate,
 
       // Attribute isolation tests
       attributeIsolationPriority,

--- a/src/utils/logger/serializer.ts
+++ b/src/utils/logger/serializer.ts
@@ -17,7 +17,7 @@ export interface SerializationConfig {
 
 export const defaultSerializationConfig: SerializationConfig = {
   maxCodingAgentMessageLength: 1000,
-  maxToolInputLength: 200,
+  maxToolInputLength: 250,
 };
 
 export const claudeCodeSerializer = (message: SDKMessage) => {


### PR DESCRIPTION
## What this PR does

- Add `makePerMutatorStateSyncTestsForStatus`, which dynamically generates systematic tests for status synchronization based on the app info collected in the prior discovery phase. For each mutator, test that changing the status via that mutator updates the other views accordingly.
- Unrelated infra: Use the original test case descriptive name in the test result

Will add more tests after I add some way to limit the number of running jobs / calls to CC.

## Anec-notes on false alarm rate, detection rate

These more systematic tests seem to be qualitatively much better at detecting state synch issues.

No false alarm issues either when I did one run with each of claude 1-3 (bracketing one weird run that I think was wonky due to memory leak issues or something).

## Logs from runs with codex-1 and codex-2

(note that some of the other test cases were commented out to speed up the runs)

### With Codex 1

```
[00:33:30.370] DEBUG: AppInfo fixture
    todoListInfo: {
      "viewsForAddingTask": {
        "views": [
          {
            "viewType": "mutator",
            "shortDescription": "Text input field for entering new task text",
            "howToAccess": "Located at the top of the app interface"
          },
          {
            "viewType": "mutator",
            "shortDescription": "Add button to submit and create new task",
            "howToAccess": "Next to the text input field"
          }
        ],
        "pathsToCode": [
          "src/App.jsx:8-32",
          "src/App.jsx:157-160",
          "src/App.jsx:185"
        ],
        "notes": {
          "notesType": "noObviousBugs"
        }
      },
      "viewsForRemovingTask": {
        "views": [
          {
            "viewType": "mutator",
            "shortDescription": "Delete button that immediately removes the task",
            "howToAccess": "In each task row, on the right side"
          }
        ],
        "pathsToCode": [
          "src/App.jsx:128",
          "src/App.jsx:179",
          "src/App.jsx:187"
        ],
        "notes": {
          "notesType": "noObviousBugs"
        }
      },
      "notes": {
        "notesType": "noObviousBugs"
      }
    }
    taskInfo: {
      "statuses": [
        "not-started",
        "in-progress",
        "under-review",
        "blocked",
        "done"
      ],
      "priorityLevels": [
        "low",
        "medium",
        "high",
        "urgent"
      ],
      "views": {
        "status": {
          "views": [
            {
              "viewType": "observer",
              "shortDescription": "Read-only status badge showing current status",
              "howToAccess": "Displayed in each task row as a colored badge"
            },
            {
              "viewType": "mutator",
              "shortDescription": "Checkbox that marks task as done/undone",
              "howToAccess": "Left side of each task row"
            },
            {
              "viewType": "mutator",
              "shortDescription": "Status dropdown menu with all status options",
              "howToAccess": "Click 'Edit' on a task to reveal the status dropdown"
            }
          ],
          "pathsToCode": [
            "src/App.jsx:64-69",
            "src/App.jsx:86-92",
            "src/App.jsx:114-117",
            "src/App.jsx:161-178"
          ],
          "notes": {
            "notesType": "potentialBugs",
            "explanation": "The app has two ways to control task completion status: (1) a checkbox that toggles between done/not-done and (2) a status dropdown that can be set to 'Done'. These two views are synchronized - checking the checkbox sets status to 'done' and setting status to 'done' checks the checkbox. However, there's a behavioral issue: when unchecking a task that was previously in a non-'not-started' status (like 'in-progress'), it defaults back to 'not-started' rather than remembering the previous status. This means users lose their previous status information when toggling the checkbox."
          }
        },
        "priority": {
          "views": [
            {
              "viewType": "observer",
              "shortDescription": "Read-only priority badge showing current priority level",
              "howToAccess": "Displayed in each task row as a colored badge next to status"
            },
            {
              "viewType": "mutator",
              "shortDescription": "Priority dropdown menu with all priority options",
              "howToAccess": "Click 'Edit' on a task to reveal the priority dropdown"
            }
          ],
          "pathsToCode": [
            "src/App.jsx:94-99",
            "src/App.jsx:115-116",
            "src/App.jsx:39",
            "src/App.jsx:47-50"
          ],
          "notes": {
            "notesType": "noObviousBugs"
          }
        },
        "dueDate": {
          "views": [
            {
              "viewType": "observer",
              "shortDescription": "Read-only due date badge showing the due date",
              "howToAccess": "Displayed in task row as 'Due YYYY-MM-DD' badge (only when due date is set)"
            },
            {
              "viewType": "mutator",
              "shortDescription": "Date input field for setting due date",
              "howToAccess": "Click 'Edit' on a task to reveal the date input field"
            }
          ],
          "pathsToCode": [
            "src/App.jsx:101",
            "src/App.jsx:116-117",
            "src/App.jsx:40",
            "src/App.jsx:49"
          ],
          "notes": {
            "notesType": "noObviousBugs"
          }
        }
      }
    }
[...]
[00:36:43.906] ERROR: ✗ Suite "Todolist Functionality Tests" failed: 2/11 tests failed
[00:36:43.906] ERROR:   • Test state synchronization of status state (if applicable): Status synchronization between checkbox and status badge works in both directions, but there is a bug where unchecking a task loses the previous status information. When a task goes from 'in-progress' to 'done' (via dropdown) and then is unchecked (via checkbox), it reverts to 'not-started' instead of returning to the previous 'in-progress' status.
[00:36:43.906] ERROR:   • Per-mutator state synchronization test - status: Status synchronization bug: When marking a task as done via checkbox, the status badge correctly shows 'done' but the status dropdown still shows 'not-started' instead of 'done'. The checkbox and status badge are synchronized, but the dropdown is not.
[00:36:43.906] INFO: {
  "name": "Todolist Functionality Tests",
  "sutFolderPath": "/Users/ymh/_git/mirdin_work/results-from-code-quality-benchmark/todolist-easy/benchmark--7369-9TBNCfBR27A7/codex-1",
  "timestamp": "2025-09-09T16:33:30.359Z",
  "summary": {
    "total": 11,
    "passed": 9,
    "failed": 2,
    "skipped": 0,
    "duration": 193531
  },
  "results": [
    {
      "name": "Test that the app has more than done/not-done statuses",
      "outcome": {
        "status": "passed",
        "howTested": "Examined the codebase (App.jsx:86-92) which shows a status dropdown with 5 options: not-started, in-progress, under-review, blocked, and done. Then tested the application in browser by creating a todo item, editing it, changing status from 'not started' to 'in progress', and saving successfully. The UI correctly displays the updated status, confirming the app supports multiple statuses beyond just done/not-done."
      }
    },
    {
      "name": "Test state synchronization of status state (if applicable)",
      "outcome": {
        "status": "failed",
        "reason": "Status synchronization between checkbox and status badge works in both directions, but there is a bug where unchecking a task loses the previous status information. When a task goes from 'in-progress' to 'done' (via dropdown) and then is unchecked (via checkbox), it reverts to 'not-started' instead of returning to the previous 'in-progress' status.",
        "howTested": "Created a task, tested checkbox->badge sync (✓), tested dropdown->checkbox sync (✓), then discovered the edge case: set status to 'in-progress' via dropdown, changed to 'done' via dropdown (checkbox correctly checked), then unchecked via checkbox - status incorrectly reverted to 'not-started' instead of 'in-progress'. The app has proper bidirectional sync but fails to preserve status history when toggling the done state via checkbox."
      }
    },
    {
      "name": "Test state synchronization of priority state (if applicable)",
      "outcome": {
        "status": "passed",
        "howTested": "Created a task and tested priority synchronization between the dropdown editor (mutator view) and priority badge (observer view). Verified: 1) Changing priority from medium to high to urgent via dropdown correctly updates the badge, 2) Entering edit mode shows the correct priority in dropdown matching the badge, 3) Canceling edits properly maintains synchronization by reverting to original state. All priority values sync correctly between both views."
      }
    },
    {
      "name": "Test state synchronization of due date state (if applicable)",
      "outcome": {
        "status": "passed",
        "howTested": "Created a task, tested bidirectional synchronization between the date input field (mutator view) and due date badge (observer view). Verified setting, updating, and clearing due dates synchronize correctly across both views. Tested with multiple date values (2025-12-25, 2025-01-15) and empty values."
      }
    },
    {
      "name": "Test that changing a task's priority doesn't affect other tasks",
      "outcome": {
        "status": "passed",
        "howTested": "Created 3 tasks with diverse attributes: Task 1 (urgent priority, not-started, due tomorrow), Task 2 (high priority, under-review, due next week), Task 3 (low priority, done, due yesterday). Recorded initial state, then changed Task 1's priority from urgent to medium. Verified that Tasks 2 and 3 retained all original attributes (priority: high/low, status: under-review/done, due dates: 2025-09-16/2025-09-08) unchanged after Task 1's priority modification."
      }
    },
    {
      "name": "Test that changing a task's status doesn't affect other tasks",
      "outcome": {
        "status": "passed",
        "howTested": "Created 3 tasks with diverse attributes: Task 1 (urgent priority, not-started status, due 2025-09-10), Task 2 (high priority, under-review status, due 2025-09-16), and Task 3 (low priority, done status, due 2025-09-08). Recorded initial state of all tasks, then changed Task 1's status from 'not started' to 'in progress'. Verified that Task 2 retained all original attributes (under review status, high priority, due 2025-09-16) and Task 3 retained all original attributes (done status with checkbox checked, low priority, due 2025-09-08). No attributes of other tasks were affected by the status change."
      }
    },
    {
      "name": "Test that changing a task's due date doesn't affect other tasks",
      "outcome": {
        "status": "passed",
        "howTested": "Created 3 tasks with diverse attributes (Task 1: urgent/not-started/due tomorrow, Task 2: high/under-review/due next week, Task 3: low/done/due yesterday). Recorded initial state, changed Task 1's due date from 2025-09-10 to 2025-09-15, then verified Tasks 2 and 3 retained all original attributes. Task 2 remained: under-review/high/2025-09-16, Task 3 remained: done/low/2025-09-08."
      }
    },
    {
      "name": "Per-mutator state synchronization test - status",
      "outcome": {
        "status": "failed",
        "reason": "Status synchronization bug: When marking a task as done via checkbox, the status badge correctly shows 'done' but the status dropdown still shows 'not-started' instead of 'done'. The checkbox and status badge are synchronized, but the dropdown is not.",
        "howTested": "Created a task, checked the checkbox to mark it done, verified the status badge showed 'done', then opened edit mode and found the dropdown still selected 'Not started' instead of 'Done'"
      }
    },
    {
      "name": "Per-mutator state synchronization test - status",
      "outcome": {
        "status": "passed",
        "howTested": "Created a task 'Test synchronization task' with initial status 'not started' and unchecked checkbox. Used Edit button to access status dropdown, changed status from 'Not started' to 'Done', and clicked Save. Verified that both the status badge updated to 'done' and the checkbox became checked, demonstrating proper synchronization between all views."
      }
    },
    {
      "name": "Per-mutator state synchronization test - status",
      "outcome": {
        "status": "passed",
        "howTested": "Created a task, used checkbox to mark it as done (verified status badge updated to 'done'), then unchecked the checkbox to mark it as not-done (verified status badge updated to 'not started'), and confirmed the status dropdown also showed 'Not started' when editing. All views (checkbox, status badge, status dropdown) synchronized correctly."
      }
    },
    {
      "name": "Per-mutator state synchronization test - status",
      "outcome": {
        "status": "passed",
        "howTested": "Created a task, marked it as done using the checkbox (verified status badge updated to 'done' and checkbox became checked), then unmarked it using the checkbox (verified status badge reverted to 'not started' and checkbox became unchecked). Also tested the reverse direction by using the Edit dropdown to change status to 'Done' and verified the checkbox automatically became checked. All views synchronized correctly in both directions."
      }
    }
  ]
}
[00:36:43.906] INFO: Test execution for Todolist Functionality Tests completed in 193.5s
```

### With Codex 2

```
[00:26:40.385] DEBUG: AppInfo fixture
    todoListInfo: {
      "viewsForAddingTask": {
        "views": [
          {
            "viewType": "mutator",
            "shortDescription": "Text input field for task description",
            "howToAccess": "Directly visible at the top of the form"
          },
          {
            "viewType": "mutator",
            "shortDescription": "Status dropdown for selecting initial task status",
            "howToAccess": "In the add task form, next to the text input"
          },
          {
            "viewType": "mutator",
            "shortDescription": "Priority dropdown for selecting initial task priority",
            "howToAccess": "In the add task form, next to the status dropdown"
          },
          {
            "viewType": "mutator",
            "shortDescription": "Due date input field for setting task due date",
            "howToAccess": "In the add task form, next to the priority dropdown"
          },
          {
            "viewType": "mutator",
            "shortDescription": "Add button to create the task",
            "howToAccess": "At the end of the add task form"
          }
        ],
        "pathsToCode": [
          "src/App.jsx:22-67"
        ],
        "notes": {
          "notesType": "noObviousBugs"
        }
      },
      "viewsForRemovingTask": {
        "views": [
          {
            "viewType": "mutator",
            "shortDescription": "Delete button that removes the task immediately",
            "howToAccess": "In each task row, in the actions section on the right"
          }
        ],
        "pathsToCode": [
          "src/App.jsx:155",
          "src/App.jsx:206"
        ],
        "notes": {
          "notesType": "noObviousBugs"
        }
      },
      "notes": {
        "notesType": "noObviousBugs"
      }
    }
    taskInfo: {
      "statuses": [
        "not-started",
        "in-progress",
        "under-review",
        "blocked"
      ],
      "priorityLevels": [
        "low",
        "medium",
        "high",
        "urgent"
      ],
      "views": {
        "status": {
          "views": [
            {
              "viewType": "mutator",
              "shortDescription": "Checkbox that toggles the task's done/not-done state",
              "howToAccess": "At the left of each task row"
            },
            {
              "viewType": "mutator",
              "shortDescription": "Status dropdown menu for selecting task status",
              "howToAccess": "In each task row, in the controls section"
            },
            {
              "viewType": "observer",
              "shortDescription": "Visual strikethrough on task text when marked as done",
              "howToAccess": "Automatically visible when checkbox is checked"
            }
          ],
          "pathsToCode": [
            "src/App.jsx:87-93",
            "src/App.jsx:116-125",
            "src/App.jsx:195",
            "src/index.css:83-86"
          ],
          "notes": {
            "notesType": "potentialBugs",
            "explanation": "There are two independent systems for task completion state: (1) a 'done' boolean controlled by the checkbox that visually strikes through the text, and (2) a separate 'status' field with four predefined values (not-started, in-progress, under-review, blocked) controlled by the status dropdown. These two state systems operate completely independently - checking the done checkbox does not change the status dropdown value, and changing the status dropdown does not affect the done checkbox state. This creates a confusing user experience where a task can be simultaneously marked as 'done' (checkbox checked, text crossed out) and have a status of 'blocked' or 'not-started'. The specification should clarify whether 'done' should be treated as a special status that synchronizes with the status dropdown (e.g., automatically setting status to a hypothetical 'done' value) or if these are meant to be truly independent dimensions of task state."
          }
        },
        "priority": {
          "views": [
            {
              "viewType": "mutator",
              "shortDescription": "Priority dropdown menu for selecting task priority level",
              "howToAccess": "In each task row, in the controls section next to the status dropdown"
            }
          ],
          "pathsToCode": [
            "src/App.jsx:126-136"
          ],
          "notes": {
            "notesType": "noObviousBugs"
          }
        },
        "dueDate": {
          "views": [
            {
              "viewType": "mutator",
              "shortDescription": "Date input field for setting/changing task due date",
              "howToAccess": "In each task row, in the controls section next to the priority dropdown"
            }
          ],
          "pathsToCode": [
            "src/App.jsx:137-144"
          ],
          "notes": {
            "notesType": "noObviousBugs"
          }
        }
      }
    }

[...]

[00:28:32.169] INFO: {
  "name": "Todolist Functionality Tests",
  "sutFolderPath": "[redacted]/results-from-code-quality-benchmark/todolist-easy/benchmark--7369-9TBNCfBR27A7/codex-2",
  "timestamp": "2025-09-09T16:26:40.382Z",
  "summary": {
    "total": 6,
    "passed": 1,
    "failed": 5,
    "skipped": 0,
    "duration": 111771
  },
  "results": [
    {
      "name": "Test that the app has more than done/not-done statuses",
      "outcome": {
        "status": "passed",
        "howTested": "Examined source code (App.jsx:8-13) which defines STATUS_OPTIONS array with 4 distinct statuses: not-started, in-progress, under-review, and blocked. Verified functionality by opening the app at localhost:3000, creating a todo item, and successfully changing its status through all available options using the dropdown menus."
      }
    },
    {
      "name": "Test state synchronization of status state (if applicable)",
      "outcome": {
        "status": "failed",
        "reason": "The task status is exposed through two independent UI elements that do not synchronize with each other: (1) a checkbox that toggles 'done' state with visual strikethrough, and (2) a status dropdown with predefined values (not-started, in-progress, under-review, blocked). Checking the 'done' checkbox does not update the status dropdown, and changing the status dropdown does not affect the checkbox state. This creates a confusing user experience where tasks can appear simultaneously 'done' (checked with strikethrough text) and have contradictory status values like 'blocked' or 'not-started'.",
        "howTested": "Created test tasks, verified that checking the 'done' checkbox applies strikethrough styling but leaves the status dropdown unchanged at 'In progress'. Also verified that changing the status dropdown to 'Blocked' does not affect the checkbox state. Screenshots document both UI elements operating independently without synchronization."
      }
    },
    {
      "name": "Per-mutator state synchronization test - status",
      "outcome": {
        "status": "failed",
        "reason": "The checkbox (done/not-done state) and the status dropdown operate completely independently with no synchronization. When the checkbox is checked, the status dropdown does not change from its current value (e.g., 'Not started' remains 'Not started'). Conversely, when the status dropdown is changed (e.g., from 'Not started' to 'In progress'), the checkbox state remains unchanged. The two state systems do not synchronize with each other.",
        "howTested": "Created a task with 'Not started' status, then checked the checkbox (which visually struck through the text) but the status dropdown remained 'Not started'. Then unchecked the checkbox and changed status to 'In progress', but the checkbox remained unchecked. No synchronization occurs in either direction between the two state systems."
      }
    },
    {
      "name": "Per-mutator state synchronization test - status",
      "outcome": {
        "status": "failed",
        "reason": "The done checkbox and status dropdown operate independently. When checking the done checkbox, the task text gets strikethrough styling but the status dropdown remains unchanged at 'Not started'. The two state systems do not synchronize - a task can be simultaneously marked as done (checkbox checked, text crossed out) and have a status of 'not-started'.",
        "howTested": "Created a task with 'not-started' status, checked the done checkbox to mark it as completed, then verified that while the checkbox became checked and the task text showed strikethrough styling, the status dropdown still displayed 'Not started' instead of updating to reflect the completed state."
      }
    },
    {
      "name": "Per-mutator state synchronization test - status",
      "outcome": {
        "status": "failed",
        "reason": "The done checkbox and status dropdown operate independently without synchronization. When marking a task as done/not-done via the checkbox, the status dropdown does not update accordingly, and vice versa. The visual strikethrough updates correctly with the checkbox state, but the status field remains unchanged, creating two separate and unrelated completion tracking systems.",
        "howTested": "Created a task, toggled the done checkbox from unchecked to checked (which applied strikethrough to text), then back to unchecked (which removed strikethrough). Throughout this process, the status dropdown remained at 'Not started' and did not reflect the done/not-done state changes, demonstrating the lack of synchronization between the two completion tracking mechanisms."
      }
    },
    {
      "name": "Per-mutator state synchronization test - status",
      "outcome": {
        "status": "failed",
        "reason": "The checkbox (done/not-done state) and status dropdown operate independently without synchronization. When the checkbox is checked, the task gets visual strikethrough styling but the status dropdown remains unchanged. Similarly, changing the status dropdown does not affect the checkbox state. These two state systems are completely disconnected.",
        "howTested": "Created a task with 'Not started' status, checked the done checkbox (which added strikethrough styling), then changed status dropdown to 'In progress' and back to 'Not started' while observing that the checkbox state remained unchanged. Then unchecked the checkbox and verified the status dropdown was unaffected. Both state systems operate independently without any synchronization."
      }
    }
  ]
}
```
