### PR TITLE
Infra: Expose playwright output dir as a cli option for the benchmark:test-functionality script

### DIFF
--- a/src/benchmark-functionality-tests/test-lib/agents/config/playwright-mcp-config.ts
+++ b/src/benchmark-functionality-tests/test-lib/agents/config/playwright-mcp-config.ts
@@ -8,19 +8,28 @@ export function makePlaywrightMCPConfig(
   capabilities: PlaywrightMCPCapability[],
   testRunnerConfig: TestRunnerConfig,
 ) {
+  const args = [
+    "-y",
+    PLAYWRIGHT_MCP,
+    "--isolated",
+    testRunnerConfig.getPlaywrightBrowserModeFlag(),
+  ];
+
+  // Save output (traces, session) if an output dir path was provided
+  const outputDir = testRunnerConfig.getPlaywrightOutDir();
+  if (outputDir) {
+    args.push("--output-dir", outputDir, "--save-trace", "--save-session");
+  }
+
+  if (capabilities.length > 0) {
+    args.push(`--caps=${capabilities.join(",")}`);
+  }
+
   return {
     playwright: {
       type: "stdio" as const,
       command: "npx",
-      args: [
-        "-y",
-        PLAYWRIGHT_MCP,
-        "--isolated",
-        "--save-trace",
-        "--save-session",
-        testRunnerConfig.getPlaywrightBrowserModeFlag(),
-        capabilities.length > 0 ? `--caps=${capabilities.join(",")}` : "",
-      ],
+      args,
     },
   };
 }

--- a/src/benchmark-functionality-tests/test-lib/runner.ts
+++ b/src/benchmark-functionality-tests/test-lib/runner.ts
@@ -41,6 +41,7 @@ export class TestRunnerConfig {
     loggerConfig: { logger: Logger; logLevel: LogLevel },
     maxConcurrentTests: number,
     browserIsHeaded: boolean,
+    playwrightOutDir?: string,
     // timeoutMs: number;
   ) {
     // Need to error in order for the benchmark args parser to error if the config options not valid
@@ -55,6 +56,7 @@ export class TestRunnerConfig {
       loggerConfig,
       maxConcurrentTests,
       browserIsHeaded,
+      playwrightOutDir && path.resolve(playwrightOutDir),
     );
   }
 
@@ -64,6 +66,8 @@ export class TestRunnerConfig {
     private readonly maxConcurrentTests: number,
     /** Have playwright run browser in headed (show browser window) vs. headless mode */
     private readonly browserIsHeaded: boolean,
+    /** Abs path to directory for Playwright MCP output files (traces, sessions) */
+    private readonly playwrightOutDir?: string,
     // timeoutMs: number;
   ) {}
 
@@ -87,6 +91,11 @@ export class TestRunnerConfig {
     return this.browserIsHeaded ? "--headed" : "--headless";
   }
 
+  /** Abs path to directory for Playwright MCP output files */
+  getPlaywrightOutDir(): string | undefined {
+    return this.playwrightOutDir;
+  }
+
   toPretty(): string {
     const simplifiedConfig = {
       folderPath: this.getSutConfig().folderPath,
@@ -94,6 +103,7 @@ export class TestRunnerConfig {
       browserIsHeaded: this.browserIsHeaded,
       logLevel: this.loggerConfig.logLevel,
       maxConcurrentTests: this.maxConcurrentTests,
+      playwrightOutDir: this.playwrightOutDir,
     };
     return jsonStringify(simplifiedConfig);
   }

--- a/src/benchmark-test-functionality.ts
+++ b/src/benchmark-test-functionality.ts
@@ -1,6 +1,15 @@
 #!/usr/bin/env node
 import * as path from "node:path";
-import { command, flag, number, option, positional, run, string } from "cmd-ts";
+import {
+  command,
+  flag,
+  number,
+  option,
+  optional,
+  positional,
+  run,
+  string,
+} from "cmd-ts";
 import { Reporter } from "./benchmark-functionality-tests/test-lib/report.ts";
 import {
   TestRunner,
@@ -44,6 +53,14 @@ const cmd = command({
       description: "Run browser in headed mode (show browser window)",
       defaultValue: () => false,
     }),
+    playwrightOutDir: option({
+      type: optional(string),
+      long: "playwrightOutDir",
+      description:
+        "Directory for Playwright MCP traces and sessions (won't save if not provided)",
+      // Requiring the user to provide a path if they want PW mcp to be saved,
+      // to pre-empt potential data contamination/leakage issues from, e.g., unintentionally exposing PW MCP output to coding agents
+    }),
   },
   handler: async ({
     benchmarkPath,
@@ -51,6 +68,7 @@ const cmd = command({
     port,
     maxConcurrentTests,
     headed,
+    playwrightOutDir,
   }) => {
     const resolvedBenchmarkPath = path.resolve(benchmarkPath);
     const { logger, logLevel } = getLoggerConfig();
@@ -65,6 +83,7 @@ const cmd = command({
         { logger, logLevel },
         maxConcurrentTests,
         headed,
+        playwrightOutDir,
       );
       const runner = new TestRunner(config);
       logger.info(`Started test runner with config\n${config.toPretty()}\n`);


### PR DESCRIPTION
From quick manual inspection/manual tests, it does look like it's saving the pw output if and only if the output dir was supplied