### PR TITLE
Refactor: Improve type safety for InstanceResult; add mempty method to DiffStats

### DIFF
--- a/src/benchmark-lib.ts
+++ b/src/benchmark-lib.ts
@@ -15,7 +15,7 @@ export function outputBenchmarkResults(
 ): void {
   // Output benchmark results as JSON
   const successCount = result.updates.filter(
-    (u: InstanceResult) => u.success,
+    (u: InstanceResult) => u.result.type === "invocationCompleted",
   ).length;
   const totalUpdates = result.updates.length;
 
@@ -28,8 +28,8 @@ export function outputBenchmarkResults(
       agentStats[u.agentName] = { successful: 0, total: 0, totalScore: 0 };
     }
     agentStats[u.agentName].total++;
-    agentStats[u.agentName].totalScore += u.score;
-    if (u.success) {
+    agentStats[u.agentName].totalScore += u.result.score;
+    if (u.result.type === "invocationCompleted") {
       agentStats[u.agentName].successful++;
     }
   });
@@ -37,10 +37,13 @@ export function outputBenchmarkResults(
   const updates = result.updates.map((u: InstanceResult) => ({
     instance: u.instanceId,
     agent: u.agentName,
-    success: u.success,
-    score: u.score,
-    diffStats: u.diffStats || { filesChanged: 0, insertions: 0, deletions: 0 },
-    executionTime: u.executionTime,
+    success: u.result.type === "invocationCompleted",
+    score: u.result.score,
+    diffStats:
+      u.result.type === "invocationCompleted"
+        ? u.result.diffStats.getSummaryStats()
+        : { filesChanged: 0, linesChanged: 0 },
+    executionTime: u.executionTimeMs,
   }));
 
   console.log(

--- a/src/evaluator/diff-stats.ts
+++ b/src/evaluator/diff-stats.ts
@@ -10,7 +10,7 @@ export class DiffStats {
     0,1,0,"b"
     1,0,0,"b/d"
     ```
-  * 
+  *
   * ```
     ❯ git diff -M | diffstat -tm
     INSERTED,DELETED,MODIFIED,FILENAME
@@ -18,6 +18,11 @@ export class DiffStats {
     3,0,1,"path/someotherfile.txt"
     ```
  */
+
+  static mempty(): DiffStats {
+    return new DiffStats({ filesChanged: 0, linesChanged: 0 }, []);
+  }
+
   static makeFromDiffstat(diffstatOutput: string): DiffStats {
     const lines = diffstatOutput.trim().split("\n");
 

--- a/src/evaluator/types.ts
+++ b/src/evaluator/types.ts
@@ -74,6 +74,24 @@ export interface EvaluationMetadata {
   config: EvaluationConfig;
 }
 
+// Type guard functions
+
+export function updateCompleted(
+  instance: InstanceResult,
+): instance is InstanceResult & {
+  result: { type: "invocationCompleted"; score: number; diffStats: DiffStats };
+} {
+  return instance.result.type === "invocationCompleted";
+}
+
+export function updateFailed(
+  instance: InstanceResult,
+): instance is InstanceResult & {
+  result: { type: "invocationFailed"; score: 0; error: Error };
+} {
+  return instance.result.type === "invocationFailed";
+}
+
 export class EvaluationError extends Error {
   constructor(
     message: string,

--- a/src/evaluator/types.ts
+++ b/src/evaluator/types.ts
@@ -1,5 +1,5 @@
 import type { ClaudeAgentConfig } from "../agents/types.ts";
-import type { DiffStats } from "./diff-stats.ts";
+import { DiffStats } from "./diff-stats.ts";
 
 export interface EvaluationConfig {
   workspaceRoot?: string;
@@ -17,15 +17,53 @@ export interface EvaluationResult {
   totalScore: number;
 }
 
+// TODO: Refactor to use serialized errors later
+/** Scored result of an agent's feature addition attempt. */
 export interface InstanceResult {
   instanceId: string;
   folderPath: string;
-  success: boolean;
-  error?: Error;
-  executionTime: number;
-  diffStats?: DiffStats;
   agentName: string;
-  score: number;
+  executionTimeMs: number;
+  result:
+    | { type: "invocationFailed"; score: 0; error: Error }
+    | { type: "invocationCompleted"; score: number; diffStats: DiffStats };
+}
+
+// Helper functions for agents to create InstanceResult with mempty values
+
+export function makeInvocationCompletedMempty(
+  instanceId: string,
+  folderPath: string,
+  agentName: string,
+  executionTimeMs: number,
+): InstanceResult {
+  return {
+    instanceId,
+    folderPath,
+    agentName,
+    executionTimeMs,
+    result: {
+      type: "invocationCompleted",
+      score: 0,
+      diffStats: DiffStats.mempty(),
+    },
+  };
+}
+
+export function makeInvocationFailed(
+  instanceId: string,
+  folderPath: string,
+  agentName: string,
+  executionTimeMs: number,
+  error: Error,
+): InstanceResult {
+  return {
+    instanceId,
+    folderPath,
+    agentName,
+    executionTimeMs,
+    result: { type: "invocationFailed", score: 0, error },
+  };
 }
 
 export interface EvaluationMetadata {


### PR DESCRIPTION
Refactor InstanceResult to
```
// TODO: Refactor to use serialized errors later
export interface InstanceResult {
  instanceId: string;
  folderPath: string;
  agentName: string;
  executionTimeMs: number;
  result:
    | { type: "invocationFailed"; score: 0; error: Error }
    | { type: "invocationCompleted"; score: number; diffStats: DiffStats };
}

```