### PR TITLE
Feature agent x evaluator cleanup: Refactor feature agent interface to use InstanceDescriptor parameter and rename runFeatureAgent to tryApplyUpdate

### DIFF
--- a/harness/agents/types.ts
+++ b/harness/agents/types.ts
@@ -1,4 +1,5 @@
 import { Data, type Effect } from "effect";
+import type { InstanceDescriptor } from "../evaluator/instance.ts";
 import type { SuccessInstanceResult } from "../evaluator/result";
 import type { LoggerConfig } from "../utils/logger/logger.ts";
 
@@ -22,9 +23,7 @@ export interface FeatureAgent {
   getName(): string;
   applyUpdate(
     updatePrompt: string,
-    folderPath: string,
-    instanceId: string,
-    port: number,
+    instance: InstanceDescriptor,
   ): Effect.Effect<SuccessInstanceResult, FeatureAgentError, LoggerConfig>;
 }
 

--- a/harness/evaluator/instance.ts
+++ b/harness/evaluator/instance.ts
@@ -6,10 +6,9 @@ import type { EvaluationConfig } from "./config.ts";
 
 export type InstanceDescriptor = {
   readonly instanceId: string;
-  readonly agentName: string;
-  readonly agent: FeatureAgent;
   readonly instancePath: string;
   readonly port: number;
+  readonly agent: FeatureAgent;
 };
 
 export function makeInstances(
@@ -29,7 +28,6 @@ export function makeInstances(
           const instanceId = `${agent.getName()}-${instanceIdx + 1}`;
           return {
             instanceId,
-            agentName: agent.getName(),
             agent,
             instancePath: path.join(workspaceDir, instanceId),
             port:

--- a/harness/evaluator/result.ts
+++ b/harness/evaluator/result.ts
@@ -1,6 +1,7 @@
 import type { TestSuiteResult } from "../benchmark-test-lib/report.ts";
 import type { EvaluationMetadata } from "./config.ts";
 import { DiffStats } from "./diff-stats.ts";
+import type { InstanceDescriptor } from "./instance.ts";
 
 /*********************
    EvaluationResult
@@ -96,18 +97,16 @@ export function makeSuccessInstanceResult(
 }
 
 export function makeFailedInstanceResult(
-  instanceId: string,
-  folderPath: string,
-  agentName: string,
+  instance: InstanceDescriptor,
   executionTimeMs: number,
   cause: string,
   errorType?: string,
 ): FailedInstanceResult {
   return {
     type: "FailedInstanceResult",
-    instanceId,
-    folderPath,
-    agentName,
+    instanceId: instance.instanceId,
+    folderPath: instance.instancePath,
+    agentName: instance.agent.getName(),
     executionTimeMs,
     cause,
     errorType,


### PR DESCRIPTION
Feature agent x evaluator cleanup: Refactor feature agent interface to use InstanceDescriptor parameter and rename runFeatureAgent to tryApplyUpdate

Primary changes

* Rename `runFeatureAgent` to the more precise `tryApplyUpdate`. 
* FeatureAgent: Refactor applyUpdate method signature etc to use InstanceDescriptors instead of passing around individual parameters, to make it more future-proof. 
* makeFailedInstanceResult: Update to accept InstanceDescriptor directly instead of individual fields, deriving agentName via instance.agent.getName() rather than storing it redundantly

Secondary changes

- Remove redundant agentName property from InstanceDescriptor interface in instance.ts:9
- Reorder InstanceDescriptor properties for logical grouping (ID/path/port, then agent)