### PR TITLE
Functionality test errors: Quick cleanup -- Fix TestSuiteImportError tag mismatch and restore informative error messages for test loading failures

### DIFF
--- a/harness/benchmark-test-lib/errors.ts
+++ b/harness/benchmark-test-lib/errors.ts
@@ -56,14 +56,18 @@ export type TestLoadError = InvalidBenchmarkPathError | TestSuiteImportError;
 export class InvalidBenchmarkPathError extends Data.TaggedError(
   "InvalidBenchmarkPathError",
 )<{
+  readonly message: string;
   readonly benchmarkPath: string;
   readonly expectedFormat: string;
 }> {}
 
 export class TestSuiteImportError extends Data.TaggedError(
-  "StrategyImportError",
+  "TestSuiteImportError",
 )<{
+  readonly message: string;
+  readonly benchmarkSet: string;
+  readonly project: string;
   readonly testSuiteStrategyPath: string;
   readonly availableStrategies: string;
-  readonly underlyingError?: unknown;
+  readonly cause?: unknown;
 }> {}

--- a/harness/benchmark-test-lib/test-registry.ts
+++ b/harness/benchmark-test-lib/test-registry.ts
@@ -5,6 +5,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import dedent from "dedent";
 import { Effect } from "effect";
 import {
   InvalidBenchmarkPathError,
@@ -142,9 +143,16 @@ function getSuiteGenerationStrategy(
         .join(", ");
 
       return new TestSuiteImportError({
+        message: dedent`
+          Failed to load test strategy for ${benchmarkSet}/${project}.
+          Path: ${strategyPath}
+          Available strategies: ${available}
+          ${error}`,
+        benchmarkSet,
+        project,
         testSuiteStrategyPath: strategyPath,
         availableStrategies: available,
-        underlyingError: error,
+        cause: error,
       });
     },
   });
@@ -180,6 +188,9 @@ export function parseBenchmarkPath(
   ) {
     return Effect.fail(
       new InvalidBenchmarkPathError({
+        message: dedent`
+          Invalid benchmark path: ${benchmarkPath}
+          Expected format: ${BENCHMARK_PATTERN}`,
         benchmarkPath,
         expectedFormat: BENCHMARK_PATTERN,
       }),


### PR DESCRIPTION
Functionality test errors: Quick cleanup -- Fix TestSuiteImportError tag mismatch and restore informative error messages for test loading failures

1. Error tagging fix: Correct TestSuiteImportError._tag from "StrategyImportError" to "TestSuiteImportError" to
 ensure proper error type detection with Predicate.isTagged() and accurate error logging
2. Error message restoration: Add message field to both InvalidBenchmarkPathError and TestSuiteImportError to
preserve the multiline, user-friendly error guidance that was lost when migrating to tagged errors
3. Enhanced error context: Add benchmarkSet and project fields to TestSuiteImportError and populate cause field
 in both error types for richer error reporting and debugging