### PR TITLE
logging, erroring: Improve error context propagation and logging

### DIFF
--- a/harness/agents/feature-addition/codex-agent.ts
+++ b/harness/agents/feature-addition/codex-agent.ts
@@ -57,10 +57,8 @@ export class CodexAgent implements FeatureAgent {
           ),
         ),
         Effect.mapError((error) => {
-          const errorMessage =
-            error instanceof Error ? error.message : String(error);
           return new FeatureAgentError({
-            message: `Codex agent failed for instance ${instance.instanceId}: ${errorMessage}`,
+            message: `Codex agent failed for instance ${instance.instanceId}`,
             cause: error,
           });
         }),

--- a/harness/agents/shell-agent.ts
+++ b/harness/agents/shell-agent.ts
@@ -70,14 +70,10 @@ export function createShellAgent(
           Effect.runSync(
             logger.error("Failed to execute shell script", {
               script: scriptPath,
-              error: error.message,
+              error,
             }),
           );
-          resume(
-            Effect.fail(
-              new Error(`Failed to execute shell script: ${error.message}`),
-            ),
-          );
+          resume(Effect.fail(error));
         });
 
         child.on("close", (code, signal) => {
@@ -114,7 +110,10 @@ export function createShellAgent(
                 signal,
               }),
             );
-            resume(Effect.fail(new Error(errorMsg)));
+            const error = new Error(errorMsg, {
+              cause: { code, signal, script: scriptPath, folder: folderPath },
+            });
+            resume(Effect.fail(error));
           }
         });
       });

--- a/harness/benchmark-cli.ts
+++ b/harness/benchmark-cli.ts
@@ -79,7 +79,9 @@ const cli = Command.run(command, {
 cli(process.argv).pipe(
   Effect.catchAllCause((cause) =>
     Effect.gen(function* () {
-      yield* Effect.sync(() => console.error(Cause.pretty(cause)));
+      yield* Effect.sync(() =>
+        console.error(Cause.pretty(cause, { renderErrorCause: true })),
+      );
       yield* Effect.sync(() => process.exit(1));
     }),
   ),

--- a/harness/benchmark-test-lib/agents/driver-agent.ts
+++ b/harness/benchmark-test-lib/agents/driver-agent.ts
@@ -65,7 +65,7 @@ export class DriverAgentExecutionError extends Data.TaggedError(
 )<{
   readonly message: string;
   readonly sessionId?: string;
-  readonly underlyingError?: ClaudeCodeError | Error;
+  readonly cause?: ClaudeCodeError | Error;
 }> {}
 
 export class DriverAgentResponseFormatInvalid extends Data.TaggedError(
@@ -125,7 +125,7 @@ export class DriverAgent {
             new DriverAgentExecutionError({
               message: `Stream conversion error: ${streamError.message}`,
               sessionId: self.getSessionId(),
-              underlyingError: streamError,
+              cause: streamError,
             }),
         ),
       );
@@ -134,9 +134,7 @@ export class DriverAgent {
         return yield* new DriverAgentExecutionError({
           message: "Agent terminated unexpectedly",
           sessionId: self.getSessionId(),
-          underlyingError: ClaudeCodeUnexpectedTerminationError.make(
-            self.getSessionId(),
-          ),
+          cause: ClaudeCodeUnexpectedTerminationError.make(self.getSessionId()),
         });
       }
 
@@ -149,14 +147,14 @@ export class DriverAgent {
         return yield* new DriverAgentExecutionError({
           message: "Maximum turns exceeded",
           sessionId: self.getSessionId(),
-          underlyingError: ClaudeCodeMaxTurnsError.make(self.getSessionId()),
+          cause: ClaudeCodeMaxTurnsError.make(self.getSessionId()),
         });
       }
       if (isExecutionErrorResult(message)) {
         return yield* new DriverAgentExecutionError({
           message: "Execution error occurred",
           sessionId: self.getSessionId(),
-          underlyingError: ClaudeCodeExecutionError.make(self.getSessionId()),
+          cause: ClaudeCodeExecutionError.make(self.getSessionId()),
         });
       }
 

--- a/harness/benchmark-test-lib/errors.ts
+++ b/harness/benchmark-test-lib/errors.ts
@@ -45,6 +45,7 @@ export class DevServerStartupTimeoutError extends Data.TaggedError(
 )<{
   readonly url: string;
   readonly timeoutMs: number;
+  readonly cause?: unknown;
 }> {}
 
 /*************************************

--- a/harness/benchmark-test-lib/runner.ts
+++ b/harness/benchmark-test-lib/runner.ts
@@ -398,6 +398,7 @@ async function waitForServerReady(
   // c.f. Playwright:  https://github.com/microsoft/playwright/blob/f8f3e07efb4ea56bf77e90cf90bd6af754a6d2c3/packages/playwright/src/plugins/webServerPlugin.ts#L186
 
   // TODO: not sure about this way of checking for readiness
+  let lastError: unknown;
   while (Date.now() < deadline) {
     try {
       // Try main URL first
@@ -409,8 +410,9 @@ async function waitForServerReady(
         response = await fetch(`${url}index.html`);
         if (response.ok) return;
       }
-    } catch {
+    } catch (error) {
       // Server not ready yet, continue polling
+      lastError = error;
     }
 
     const delay = delays.shift() || 1000; // Progressive backoff, cap at 1s
@@ -420,5 +422,6 @@ async function waitForServerReady(
   throw new DevServerStartupTimeoutError({
     url,
     timeoutMs,
+    cause: lastError,
   });
 }

--- a/harness/evaluator/diff-stats.ts
+++ b/harness/evaluator/diff-stats.ts
@@ -1,6 +1,8 @@
-/************************************ 
+/************************************
         Diff Stats
 *************************************/
+
+import dedent from "dedent";
 
 export class DiffStats {
   /** Examples of stuff that this should parse
@@ -69,6 +71,26 @@ export class DiffStats {
 
   getDetailedStats() {
     return this.perFileStats;
+  }
+
+  toPretty(): string {
+    const summary = `${this.summaryStats.filesChanged} files, ${this.summaryStats.linesChanged} lines`;
+
+    if (this.perFileStats.length === 0) {
+      return summary;
+    }
+
+    const perFileDetails = this.perFileStats
+      .map(
+        (f) =>
+          `  ${f.filename}: +${f.insertions}/-${f.deletions}/~${f.modifications}`,
+      )
+      .join("\n");
+
+    return dedent`
+      ${summary}
+      ${perFileDetails}
+    `;
   }
 }
 

--- a/harness/evaluator/errors.ts
+++ b/harness/evaluator/errors.ts
@@ -2,9 +2,9 @@ export class EvaluationError extends Error {
   constructor(
     message: string,
     public readonly code: string,
-    public readonly details?: unknown,
+    cause?: unknown,
   ) {
-    super(message);
+    super(message, { cause });
     this.name = "EvaluationError";
   }
 }

--- a/harness/evaluator/evaluator.ts
+++ b/harness/evaluator/evaluator.ts
@@ -20,7 +20,6 @@ import { type InstanceDescriptor, makeInstances } from "./instance.ts";
 import {
   type EvaluationResult,
   type FailedInstanceResult,
-  getDiffStats,
   isFailedInstanceResult,
   isSuccessInstanceResult,
   makeFailedInstanceResult,
@@ -458,15 +457,18 @@ const tryApplyUpdate = (
         onFailure: (cause) =>
           Effect.gen(function* () {
             const elapsed = yield* Effect.sync(() => Date.now() - startTime);
-            const prettyCause = Cause.pretty(cause);
             yield* logger.error(
               `Feature agent failed for ${instance.instanceId}`,
               {
-                cause: prettyCause,
+                cause,
               },
             );
 
-            return makeFailedInstanceResult(instance, elapsed, prettyCause);
+            return makeFailedInstanceResult(
+              instance,
+              elapsed,
+              Cause.pretty(cause, { renderErrorCause: true }),
+            );
           }),
         onSuccess: (success) => Effect.succeed(success),
       }),

--- a/harness/evaluator/evaluator.ts
+++ b/harness/evaluator/evaluator.ts
@@ -99,7 +99,7 @@ export function evaluateUpdates(
     // Log diff stats
     const diffStats = successfulUpdates.map((r) => ({
       instance: r.instanceId,
-      stats: getDiffStats(r),
+      stats: getDiffStats(r)?.toPretty(),
     }));
 
     yield* logger.info("Evaluation completed successfully", {

--- a/harness/evaluator/evaluator.ts
+++ b/harness/evaluator/evaluator.ts
@@ -96,20 +96,13 @@ export function evaluateUpdates(
     yield* fs.writeFileString(resultsPath, JSON.stringify(result, null, 2));
     yield* logger.info(`Saved complete results to: ${resultsPath}`);
 
-    // Log diff stats
-    const diffStats = successfulUpdates.map((r) => ({
-      instance: r.instanceId,
-      stats: getDiffStats(r)?.toPretty(),
-    }));
-
     yield* logger.info("Evaluation completed successfully", {
       duration: metadata.totalDuration,
       successfulUpdates: successfulUpdates.length,
       failedUpdates: failedUpdates.length,
-      diffStats,
     });
 
-    // Also print diff stats and test suite results for visibility
+    // Print diff stats and test suite results for visibility
     yield* logger.info("\n=== Git Diff Statistics & Scores ===");
     for (const r of updateResults) {
       if (isSuccessInstanceResult(r)) {

--- a/harness/utils/claude-code-sdk/response-stream.ts
+++ b/harness/utils/claude-code-sdk/response-stream.ts
@@ -15,6 +15,7 @@ export class StreamConversionError extends Data.TaggedError(
   "StreamConversionError",
 )<{
   message: string;
+  cause?: unknown;
 }> {}
 
 export interface SessionManager {
@@ -56,6 +57,7 @@ export function consumeUntilTerminal<T extends SessionManager>(
       (error) =>
         new StreamConversionError({
           message: `Failed to convert Claude Code response stream: ${error}`,
+          cause: error,
         }),
     ).pipe(
       Stream.tap((message) =>
@@ -75,6 +77,7 @@ export function consumeUntilTerminal<T extends SessionManager>(
         Effect.fail(
           new StreamConversionError({
             message: `Stream conversion error: ${streamError instanceof Error ? streamError.message : String(streamError)}`,
+            cause: streamError,
           }),
         ),
       ),

--- a/harness/utils/claude-code-sdk/serializer.ts
+++ b/harness/utils/claude-code-sdk/serializer.ts
@@ -183,6 +183,13 @@ function sanitizeContentBlock(block: any): any {
     };
   }
 
+  if (block.type === "tool_use") {
+    return {
+      ...block,
+      input: block.input ? serializeToolInput(block.input) : undefined,
+    };
+  }
+
   if (block.type === "tool_result") {
     return {
       ...block,


### PR DESCRIPTION
logging, erroring: Improve error context propagation and logging

Primary changes

1. Error context preservation: Standardize use of cause property in error constructors across the codebase
instead of manual message concatenation, enabling proper error chain traversal and stack trace preservation in
DriverAgentExecutionError, StreamConversionError, DevServerStartupTimeoutError, and EvaluationError
    * so we can see stack trace if, e.g., shell agent invocation fails
2. Logger enhancement for Effect Cause objects: Extend logger's processAnnotations to automatically extract and
 serialize stack traces from Effect Cause annotations, converting them to pretty-printed strings while
preserving individual error stack traces in a separate stackTraces field
3. Fix serialization of tool use content blocks in Claude Code log serializer

Secondary changes

- Dev server logging: Replace all console.* calls in dev server lifecycle with proper logger calls executed via
 Runtime.runFork/Runtime.runPromise to ensure dev server errors also get saved to logfiles
- Shell agent error handling: Simplify error propagation by passing errors directly through Effect.fail rather
than re-wrapping in new Error instances
- Evaluator/DiffStats logging cleanup: 
  - DiffStats logging: Add toPretty() method for human-readable diff statistics with per-file breakdown
  - Remove redundant diffStats from final evaluation summary logging and enable
renderErrorCause: true in Cause.pretty calls for richer error output