### PR TITLE
TestRunner -- DevServerError: Don't crash harness if a DevServerError is thrown; add DevServerStartupUnknownError error

### DIFF
--- a/harness/benchmark-test-lib/errors.ts
+++ b/harness/benchmark-test-lib/errors.ts
@@ -19,7 +19,8 @@ export type DevServerError =
   | DevServerPortInUseError
   | DevServerProjectNotFoundError
   | DevServerDependenciesNotInstalledError
-  | DevServerStartupTimeoutError;
+  | DevServerStartupTimeoutError
+  | DevServerStartupUnknownError;
 
 export class DevServerPortInUseError extends Data.TaggedError(
   "DevServerPortInUseError",
@@ -44,7 +45,12 @@ export class DevServerStartupTimeoutError extends Data.TaggedError(
   "DevServerStartupTimeoutError",
 )<{
   readonly url: string;
-  readonly timeoutMs: number;
+  readonly cause?: unknown;
+}> {}
+
+export class DevServerStartupUnknownError extends Data.TaggedError(
+  "DevServerStartupUnknownError",
+)<{
   readonly cause?: unknown;
 }> {}
 


### PR DESCRIPTION
* Don't crash harness during `cqb run` / `cqb existing` if a DevServerError is thrown 
* Add DevServerStartupUnknownError error

So we have:
- run/existing commands: Dev server errors are caught and logged in the evaluator; we then continue with score=0 without crashing the harness
- test command: Dev server errors propagate to the CLI top-level handler and fail fast with exit code 1,
since tests cannot proceed without a working dev server